### PR TITLE
FIX: Program did always print usage and stopped

### DIFF
--- a/X32.c
+++ b/X32.c
@@ -868,15 +868,15 @@ socklen_t Client_ip_len = sizeof(Client_ip);	// length of addresses
 
 int main(int argc, char **argv) {
 	int i, whoto, noIP;
-	char input_ch;
+	int input_intch;
 	struct addrinfo hints;
 	struct addrinfo *result, *rp;
 //
 // Manage arguments
 	fflush(stdout);
 	noIP = 1;
-	while ((input_ch = getopt(argc, argv, "i:d:v:x:b:f:r:m:h")) != -1) {
-		switch (input_ch) {
+	while ((input_intch = getopt(argc, argv, "i:d:v:x:b:f:r:m:h")) != -1) {
+		switch ((char)input_intch) {
 		case 'i':
 			strcpy(Xip_str, optarg );
 			noIP = 0;

--- a/X32Fade.c
+++ b/X32Fade.c
@@ -756,12 +756,12 @@ main(int argc, char **argv)
 	HINSTANCE hPrevInstance = 0;
 	PWSTR pCmdLine = 0;
 	int		nCmdShow = 0;
-	char	input_ch;
+	int	input_intch;
 
 	Xverbose = Xdebug = 0;
 	// Manage arguments
-	while ((input_ch = getopt(argc, argv, "i:d:v:h")) != -1) {
-		switch (input_ch) {
+	while ((input_intch = getopt(argc, argv, "i:d:v:h")) != -1) {
+		switch ((char)input_intch) {
 		case 'd':
 			sscanf(optarg, "%d", &Xdebug);
 			break;


### PR DESCRIPTION
The return value from getopt was never -1 and therefore the program always closed while printing the usage text.

The return value from getopt is int, but the variable was char. (int) -1 is not the same as (char) -1. 
And therefor the while loop did never stop and the switch did at the and go to the default case.