### PR TITLE
Fix typos and ensure -S is properly parsed for silent mode

### DIFF
--- a/X32Wav_Xlive.c
+++ b/X32Wav_Xlive.c
@@ -450,7 +450,7 @@ int main(int argc, char **argv) {
 	wheader.Junk_bytes= 32716;
 	//
 	// manage command-line parameters
-	while ((input_intch = getopt(argc, argv, "g:f:m:h")) != -1) {
+	while ((input_intch = getopt(argc, argv, "g:f:m:h:S")) != -1) {
 		switch ((char)input_intch) {
 			case 'g':
 				sscanf(optarg, "%i", &GUI);
@@ -512,7 +512,7 @@ int main(int argc, char **argv) {
 		ShowWindow(GetConsoleWindow(), SW_HIDE); // Hide console window
 		wWinMain(hInstance, hPrevInstance, pCmdLine, nCmdFile);
 #else
-		prinft("GUI mode not supported outside of WIndows\n");
+		printf("GUI mode not supported outside of Windows\n");
 #endif
 		return 0;
 	}


### PR DESCRIPTION
Fixing a syntax error and a typo on line 529.
Adding 'S' to getopt argument list, so that -S parameter is properly parsed for silent mode